### PR TITLE
Potential fix for code scanning alert no. 76: Database query built from user-controlled sources

### DIFF
--- a/routes/updateProductReviews.ts
+++ b/routes/updateProductReviews.ts
@@ -15,7 +15,7 @@ export function updateProductReviews () {
   return (req: Request, res: Response, next: NextFunction) => {
     const user = security.authenticatedUsers.from(req) // vuln-code-snippet vuln-line forgedReviewChallenge
     db.reviewsCollection.update( // vuln-code-snippet neutral-line forgedReviewChallenge
-      { _id: req.body.id }, // vuln-code-snippet vuln-line noSqlReviewsChallenge forgedReviewChallenge
+      { _id: { $eq: req.body.id } }, // Fixed: Using $eq operator to prevent NoSQL injection
       { $set: { message: req.body.message } },
       { multi: true } // vuln-code-snippet vuln-line noSqlReviewsChallenge
     ).then(


### PR DESCRIPTION
Potential fix for [https://github.com/Bipul-2003/juice-shop/security/code-scanning/76](https://github.com/Bipul-2003/juice-shop/security/code-scanning/76)

To fix the issue, the user-controlled input (`req.body.id`) must be sanitized or validated before being embedded in the query. Two approaches are recommended for NoSQL queries:

1. **Use the `$eq` operator**: Ensures that the input is interpreted as a literal value instead of a query object. This approach works well for MongoDB queries.
2. **Validate the input type**: Explicitly check that `req.body.id` is a string (or another expected literal type) before using it in the query. Reject or sanitize the input if it does not conform to the expected type.

The best fix here is to use the `$eq` operator, as it directly addresses the NoSQL injection issue and ensures safe comparison. Additionally, the input validation approach can be combined for added security.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
